### PR TITLE
feat: sync OSC title changes to tab labels

### DIFF
--- a/client/src/renderer/hooks/useTerminal.ts
+++ b/client/src/renderer/hooks/useTerminal.ts
@@ -84,6 +84,12 @@ export function useTerminal(sessionId: string | null) {
       terminal.open(container)
       fitAddon.fit()
 
+      terminal.onTitleChange((title) => {
+        if (title && sessionId) {
+          useStore.getState().renameSession(sessionId, title)
+        }
+      })
+
       // Canvas renderer: pixel-perfect cell grid (no DOM-renderer line-width
       // jitter on scroll) and per-glyph browser rasterization (correct emoji
       // sizing, no WebGL atlas oversized-emoji bug).


### PR DESCRIPTION
## Summary

- xterm.js fires an `onTitleChange` event when it processes OSC 0/2 sequences (`\033]0;title\007`)
- Moltty was passing these sequences through to xterm but never listening for the event, so the tab label never updated
- This PR wires `terminal.onTitleChange` to `renameSession` in the store — a 4-line change

## Result

Tab labels now update dynamically from OSC title sequences, matching the behavior in iTerm2. Tested locally with Claude Code, which sends these sequences to describe the current task (e.g. `* Configure iTerm2 tab titles for Claude`).

## Test plan

- [ ] Open a session in Moltty dev build (`npm run dev`)
- [ ] Run `printf '\033]0;test title\007'` — tab label should update to "test title"
- [ ] Run `claude` — tab label should update dynamically as Claude Code works

🤖 Generated with [Claude Code](https://claude.com/claude-code)